### PR TITLE
Protected routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,25 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import {
+	BrowserRouter as Router,
+	Routes,
+	Route,
+	Navigate,
+} from 'react-router-dom';
 
 import { Home, Layout, List, ManageList, About } from './views';
 
 import { useAuth, useShoppingListData, useShoppingLists } from './api';
 
 import { useStateWithStorage } from './utils';
+
+function PrivateRoute({ children }) {
+	const { user, loading } = useAuth();
+
+	if (loading) {
+		return <div>Loading...</div>;
+	}
+
+	return user ? children : <Navigate to="/" />;
+}
 
 export function App() {
 	const [listPath, setListPath] = useStateWithStorage(
@@ -38,12 +53,18 @@ export function App() {
 					<Route path="/about" element={<About />} />
 					<Route
 						path="/list"
-						element={<List data={data} lists={lists} listPath={listPath} />}
+						element={
+							<PrivateRoute>
+								<List data={data} lists={lists} listPath={listPath} />
+							</PrivateRoute>
+						}
 					/>
 					<Route
 						path="/manage-list"
 						element={
-							<ManageList listPath={listPath} userId={userId} data={data} />
+							<PrivateRoute>
+								<ManageList listPath={listPath} userId={userId} data={data} />
+							</PrivateRoute>
 						}
 					/>
 				</Route>

--- a/src/api/useAuth.jsx
+++ b/src/api/useAuth.jsx
@@ -29,15 +29,19 @@ export const SignOutButton = () => (
  */
 export const useAuth = () => {
 	const [user, setUser] = useState(null);
+	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
-		auth.onAuthStateChanged((user) => {
+		const unsubscribe = auth.onAuthStateChanged((user) => {
 			setUser(user);
+			setLoading(false);
 			if (user) {
 				addUserToDatabase(user);
 			}
 		});
+
+		return () => unsubscribe();
 	}, []);
 
-	return { user };
+	return { user, loading };
 };

--- a/src/views/About.jsx
+++ b/src/views/About.jsx
@@ -37,7 +37,7 @@ export function About() {
 					</li>
 					<li>
 						Share your list with friends, family, colleagues or whomever you
-						wish.
+						wish
 					</li>
 				</ol>
 			</section>


### PR DESCRIPTION
## Description

Users are automatically redirected to `Home` view after they sign out.

## Related Issue

closes #64 

## Acceptance Criteria

- [x] After signing out, users should be automatically redirected to Home view

## Type of Changes

`new feature`

## Testing Steps / QA Criteria

`npm start`
navigate to browser and sign in
navigate to `List` or `Share` view and sign out, you should be redirected back to `Home` view
